### PR TITLE
Some fixes to logging.

### DIFF
--- a/src/common/util/logging.cpp
+++ b/src/common/util/logging.cpp
@@ -18,6 +18,7 @@
 
 #include <spdlog/sinks/basic_file_sink.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/sinks/dup_filter_sink.h>
 
 #include <filesystem>
 #include <vector>
@@ -34,6 +35,8 @@ std::shared_ptr<spdlog::logger> cqsp::common::util::make_logger(std::string name
     // Get log folder
     std::string save_path = GetCqspSavePath();
     std::filesystem::path log_folder = std::filesystem::path(save_path) / "logs";
+
+    auto dup_filter = std::make_shared<spdlog::sinks::dup_filter_sink_st>(std::chrono::seconds(10));
 
     // Initialize logger
     std::vector<spdlog::sink_ptr> sinks;
@@ -54,7 +57,8 @@ std::shared_ptr<spdlog::logger> cqsp::common::util::make_logger(std::string name
     auto console_logger = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
     sinks.push_back(console_logger);
 #endif
-    logger = std::make_shared<spdlog::logger>(name, sinks.begin(), sinks.end());
+    dup_filter->set_sinks(sinks);
+    logger = std::make_shared<spdlog::logger>(name, dup_filter);
 
     // Default pattern
     logger->set_pattern(DEFAULT_PATTERN);

--- a/src/engine/application.cpp
+++ b/src/engine/application.cpp
@@ -46,86 +46,67 @@
 #include "engine/cqspgui.h"
 
 namespace cqsp::engine {
-void ParseType(GLenum type) {
+const char* ParseType(GLenum type) {
     switch (type) {
         case GL_DEBUG_TYPE_ERROR:
-            SPDLOG_ERROR("Type: Error");
-            break;
+            return ("Error");
         case GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR:
-            SPDLOG_ERROR("Type: Deprecated Behaviour");
-            break;
+            return ("Deprecated Behaviour");
         case GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR:
-            SPDLOG_ERROR("Type: Undefined Behaviour");
-            break;
+            return ("Undefined Behaviour");
         case GL_DEBUG_TYPE_PORTABILITY:
-            SPDLOG_ERROR("Type: Portability");
-            break;
+            return ("Portability");
         case GL_DEBUG_TYPE_PERFORMANCE:
-            SPDLOG_ERROR("Type: Performance");
-            break;
+            return ("Performance");
         case GL_DEBUG_TYPE_MARKER:
-            SPDLOG_ERROR("Type: Marker");
-            break;
+            return ("Marker");
         case GL_DEBUG_TYPE_PUSH_GROUP:
-            SPDLOG_ERROR("Type: Push Group");
-            break;
+            return ("Push Group");
         case GL_DEBUG_TYPE_POP_GROUP:
-            SPDLOG_ERROR("Type: Pop Group");
-            break;
+            return ("Pop Group");
         case GL_DEBUG_TYPE_OTHER:
-            SPDLOG_ERROR("Type: Other");
-            break;
+            return ("Other");
     }
 }
 
-void ParseSeverity(GLenum severity) {
+const char* ParseSeverity(GLenum severity) {
     switch (severity) {
         case GL_DEBUG_SEVERITY_HIGH:
-            SPDLOG_ERROR("Severity: high");
-            break;
+            return ("high");
         case GL_DEBUG_SEVERITY_MEDIUM:
-            SPDLOG_ERROR("Severity: medium");
-            break;
+            return ("medium");
         case GL_DEBUG_SEVERITY_LOW:
-            SPDLOG_ERROR("Severity: low");
-            break;
+            return ("low");
         case GL_DEBUG_SEVERITY_NOTIFICATION:
-            SPDLOG_ERROR("Severity: notification");
-            break;
+            return ("notification");
     }
 }
+
+const char* ParseSource(GLenum source) {
+    switch (source) {
+    case GL_DEBUG_SOURCE_API:
+        return ("API");
+    case GL_DEBUG_SOURCE_WINDOW_SYSTEM:
+        return ("Window System");
+    case GL_DEBUG_SOURCE_SHADER_COMPILER:
+        return ("Shader Compiler");
+    case GL_DEBUG_SOURCE_THIRD_PARTY:
+        return ("Third Party");
+    case GL_DEBUG_SOURCE_APPLICATION:
+        return ("Application");
+    case GL_DEBUG_SOURCE_OTHER:
+        return ("Other");
+    }
+}
+
 void APIENTRY glDebugOutput(GLenum source, GLenum type, unsigned int id,
                             GLenum severity, GLsizei length,
                             const char* message, const void* userParam) {
     if (id == 131169 || id == 131185 || id == 131218 || id == 131204)
         return;  // ignore these non-significant error codes
 
-    SPDLOG_ERROR("Debug message ({}): {}", id, message);
-
-    switch (source) {
-        case GL_DEBUG_SOURCE_API:
-            SPDLOG_ERROR("Source: API");
-            break;
-        case GL_DEBUG_SOURCE_WINDOW_SYSTEM:
-            SPDLOG_ERROR("Source: Window System");
-            break;
-        case GL_DEBUG_SOURCE_SHADER_COMPILER:
-            SPDLOG_ERROR("Source: Shader Compiler");
-            break;
-        case GL_DEBUG_SOURCE_THIRD_PARTY:
-            SPDLOG_ERROR("Source: Third Party");
-            break;
-        case GL_DEBUG_SOURCE_APPLICATION:
-            SPDLOG_ERROR("Source: Application");
-            break;
-        case GL_DEBUG_SOURCE_OTHER:
-            SPDLOG_ERROR("Source: Other");
-            break;
-
-        ParseType(type);
-
-        ParseSeverity(severity);
-    }
+    SPDLOG_ERROR("{} message from {} ({}:{}): {}", ParseType(type),
+                    ParseSource(source), ParseSeverity(severity), id, message);
 }
 
 class GLWindow : public Window {

--- a/src/engine/renderer/framebuffer.cpp
+++ b/src/engine/renderer/framebuffer.cpp
@@ -32,7 +32,6 @@ cqsp::engine::FramebufferRenderer::~FramebufferRenderer() { Free(); }
 
 void cqsp::engine::FramebufferRenderer::InitTexture(int width, int height) {
     GenerateFrameBuffer(framebuffer);
-    SPDLOG_INFO("Framebuffer {}", framebuffer);
     // create a color attachment texture
     glGenTextures(1, &colorbuffer);
     glBindTexture(GL_TEXTURE_2D, colorbuffer);


### PR DESCRIPTION
Opengl logging is clearer now, and in one message for better copying and pasting.

Logging is also outputted into a duplication buffer so that duplicate messages will not be repeated thousands of times.