### PR TITLE
Refactor universe and script engine into a class

### DIFF
--- a/src/client/scenes/universescene.cpp
+++ b/src/client/scenes/universescene.cpp
@@ -63,7 +63,7 @@ void cqsp::scene::UniverseScene::Init() {
     namespace cqsps = cqsp::client::systems;
 
     using cqspco::systems::simulation::Simulation;
-    simulation = std::make_unique<Simulation>(GetUniverse(), GetApp().GetScriptInterface());
+    simulation = std::make_unique<Simulation>(GetApp().GetGame());
 
     system_renderer = new cqsps::SysStarSystemRenderer(GetUniverse(), GetApp());
     system_renderer->Initialize();

--- a/src/common/game.cpp
+++ b/src/common/game.cpp
@@ -1,4 +1,4 @@
-/* Conquer Space
+/*
 * Copyright (C) 2021 Conquer Space
 *
 * This program is free software: you can redistribute it and/or modify
@@ -14,21 +14,11 @@
 * You should have received a copy of the GNU General Public License
 * along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
-#pragma once
-
-#include <entt/entt.hpp>
-
-#include "common/universe.h"
 #include "common/game.h"
 
-namespace cqsp {
-namespace common {
-namespace systems {
-class ISimulationSystem {
- public:
-    virtual void DoSystem(Game& game) = 0;
-    virtual int Interval() { return 25; }
-};
-}  // namespace systems
-}  // namespace common
-}  // namespace cqsp
+cqsp::common::Game::Game() {
+    script_interface.Init();
+}
+
+cqsp::common::Game::~Game() {
+}

--- a/src/common/game.h
+++ b/src/common/game.h
@@ -1,4 +1,4 @@
-/* Conquer Space
+/*
 * Copyright (C) 2021 Conquer Space
 *
 * This program is free software: you can redistribute it and/or modify
@@ -16,19 +16,29 @@
 */
 #pragma once
 
-#include <entt/entt.hpp>
-
 #include "common/universe.h"
-#include "common/game.h"
+#include "common/scripting/scripting.h"
 
 namespace cqsp {
 namespace common {
-namespace systems {
-class ISimulationSystem {
- public:
-    virtual void DoSystem(Game& game) = 0;
-    virtual int Interval() { return 25; }
+/// <summary>
+/// Wrapper class for all the components of the game, so that all the game stuff can be
+/// initialized in one place.
+/// </summary>
+class Game {
+   public:
+    Game();
+    ~Game();
+
+    Universe& GetUniverse() { return universe; }
+
+    scripting::ScriptInterface& GetScriptInterface() {
+        return script_interface;
+    }
+
+   private:
+    Universe universe;
+    scripting::ScriptInterface script_interface;
 };
-}  // namespace systems
 }  // namespace common
 }  // namespace cqsp

--- a/src/common/game.h
+++ b/src/common/game.h
@@ -26,7 +26,7 @@ namespace common {
 /// initialized in one place.
 /// </summary>
 class Game {
-   public:
+ public:
     Game();
     ~Game();
 
@@ -36,7 +36,7 @@ class Game {
         return script_interface;
     }
 
-   private:
+ private:
     Universe universe;
     scripting::ScriptInterface script_interface;
 };

--- a/src/common/simulation.cpp
+++ b/src/common/simulation.cpp
@@ -81,7 +81,7 @@ void cqsp::common::systems::simulation::Simulation::tick() {
 
     for (auto& sys : system_list) {
         if (m_universe.date.GetDate() % sys->Interval() == 0) {
-            sys->DoSystem(m_game);
+            sys->DoSystem();
         }
     }
     END_TIMED_BLOCK(Game_Loop);

--- a/src/common/simulation.cpp
+++ b/src/common/simulation.cpp
@@ -42,8 +42,20 @@
 using cqsp::common::systems::simulation::Simulation;
 using cqsp::common::Universe;
 
-Simulation::Simulation(Universe &_universe, scripting::ScriptInterface &script_interface) :
-    m_universe(_universe), script_runner(_universe, script_interface) {
+/*Simulation::Simulation(Universe &_universe, scripting::ScriptInterface &script_interface) :
+    m_universe(_universe) {
+    namespace cqspcs = cqsp::common::systems;
+    AddSystem<cqspcs::InfrastructureSim>();
+    AddSystem<cqspcs::SysPopulationGrowth>();
+    AddSystem<cqspcs::SysPopulationConsumption>();
+    AddSystem<cqspcs::SysEconomy>();
+    AddSystem<cqspcs::SysFactory>();
+    //AddSystem<cqspcs::SysOrbit>();
+    AddSystem<cqspcs::SysPath>();
+}*/
+
+cqsp::common::systems::simulation::Simulation::Simulation(
+    cqsp::common::Game &game) : m_game(game), m_universe(game.GetUniverse()) {
     namespace cqspcs = cqsp::common::systems;
     AddSystem<cqspcs::InfrastructureSim>();
     AddSystem<cqspcs::SysPopulationGrowth>();
@@ -64,12 +76,12 @@ void cqsp::common::systems::simulation::Simulation::tick() {
     auto start = std::chrono::high_resolution_clock::now();
     BEGIN_TIMED_BLOCK(Game_Loop);
     BEGIN_TIMED_BLOCK(ScriptEngine);
-    this->script_runner.ScriptEngine();
+    //this->script_runner.ScriptEngine();
     END_TIMED_BLOCK(ScriptEngine);
 
     for (auto& sys : system_list) {
         if (m_universe.date.GetDate() % sys->Interval() == 0) {
-            sys->DoSystem(m_universe);
+            sys->DoSystem(m_game);
         }
     }
     END_TIMED_BLOCK(Game_Loop);

--- a/src/common/simulation.cpp
+++ b/src/common/simulation.cpp
@@ -31,6 +31,7 @@
 #include "common/systems/syspopulation.h"
 #include "common/systems/economy/sysfactory.h"
 #include "common/systems/sysinfrastructure.h"
+#include "common/systems/scriptrunner.h"
 
 #include "common/components/event.h"
 #include "common/components/organizations.h"
@@ -42,21 +43,10 @@
 using cqsp::common::systems::simulation::Simulation;
 using cqsp::common::Universe;
 
-/*Simulation::Simulation(Universe &_universe, scripting::ScriptInterface &script_interface) :
-    m_universe(_universe) {
-    namespace cqspcs = cqsp::common::systems;
-    AddSystem<cqspcs::InfrastructureSim>();
-    AddSystem<cqspcs::SysPopulationGrowth>();
-    AddSystem<cqspcs::SysPopulationConsumption>();
-    AddSystem<cqspcs::SysEconomy>();
-    AddSystem<cqspcs::SysFactory>();
-    //AddSystem<cqspcs::SysOrbit>();
-    AddSystem<cqspcs::SysPath>();
-}*/
-
 cqsp::common::systems::simulation::Simulation::Simulation(
     cqsp::common::Game &game) : m_game(game), m_universe(game.GetUniverse()) {
     namespace cqspcs = cqsp::common::systems;
+    AddSystem<cqspcs::SysScript>();
     AddSystem<cqspcs::InfrastructureSim>();
     AddSystem<cqspcs::SysPopulationGrowth>();
     AddSystem<cqspcs::SysPopulationConsumption>();
@@ -75,9 +65,6 @@ void cqsp::common::systems::simulation::Simulation::tick() {
     namespace cqspt = cqsp::common::components::types;
     auto start = std::chrono::high_resolution_clock::now();
     BEGIN_TIMED_BLOCK(Game_Loop);
-    BEGIN_TIMED_BLOCK(ScriptEngine);
-    //this->script_runner.ScriptEngine();
-    END_TIMED_BLOCK(ScriptEngine);
 
     for (auto& sys : system_list) {
         if (m_universe.date.GetDate() % sys->Interval() == 0) {

--- a/src/common/simulation.h
+++ b/src/common/simulation.h
@@ -39,12 +39,12 @@ class Simulation {
 
     template <class T>
     void AddSystem() {
+        static_assert(std::is_base_of<cqsp::common::systems::ISimulationSystem, T>::value);
         system_list.push_back(std::make_unique<T>(m_game));
     }
 
  private:
     cqsp::common::Game &m_game;
-    //cqsp::common::systems::SysEventScriptRunner script_runner;
     std::vector<std::unique_ptr<cqsp::common::systems::ISimulationSystem>> system_list;
     cqsp::common::Universe &m_universe;
 };

--- a/src/common/simulation.h
+++ b/src/common/simulation.h
@@ -19,10 +19,8 @@
 #include <memory>
 #include <vector>
 
-#include "common/universe.h"
+#include "common/game.h"
 #include "common/systems/isimulationsystem.h"
-
-#include "common/systems/scriptrunner.h"
 
 namespace cqsp {
 namespace common {
@@ -35,7 +33,7 @@ namespace simulation {
 class Simulation {
  public:
     explicit
-    Simulation(cqsp::common::Universe &_universe, scripting::ScriptInterface &script_interface);
+    Simulation(cqsp::common::Game &game);
 
     void tick();
 
@@ -45,7 +43,8 @@ class Simulation {
     }
 
  private:
-    cqsp::common::systems::SysEventScriptRunner script_runner;
+    cqsp::common::Game &m_game;
+    //cqsp::common::systems::SysEventScriptRunner script_runner;
     std::vector<std::unique_ptr<cqsp::common::systems::ISimulationSystem>> system_list;
     cqsp::common::Universe &m_universe;
 };

--- a/src/common/simulation.h
+++ b/src/common/simulation.h
@@ -39,7 +39,7 @@ class Simulation {
 
     template <class T>
     void AddSystem() {
-        system_list.push_back(std::make_unique<T>());
+        system_list.push_back(std::make_unique<T>(m_game));
     }
 
  private:

--- a/src/common/simulation.h
+++ b/src/common/simulation.h
@@ -32,8 +32,7 @@ namespace simulation {
  */
 class Simulation {
  public:
-    explicit
-    Simulation(cqsp::common::Game &game);
+    explicit Simulation(cqsp::common::Game &game);
 
     void tick();
 

--- a/src/common/systems/economy/syseconomy.cpp
+++ b/src/common/systems/economy/syseconomy.cpp
@@ -36,28 +36,28 @@
 //
 
 using cqsp::common::systems::SysEconomy;
-void SysEconomy::DoSystem(Universe& universe) {
+void SysEconomy::DoSystem(Game& game) {
     namespace cqspc = cqsp::common::components;
     BEGIN_TIMED_BLOCK(SysEconomy);
-    WalletReset(universe);
-    SysCommercialProcess(universe);
-    SysEmploymentHandler(universe);
+    WalletReset(game.GetUniverse());
+    SysCommercialProcess(game.GetUniverse());
+    SysEmploymentHandler(game.GetUniverse());
     // Produce resources
     BEGIN_TIMED_BLOCK(Resource_gen);
-    SysResourceGenerator(universe);
-    SysProduction(universe);
-    SysDemandCreator(universe);
-    SysFactoryDemandCreator(universe);
+    SysResourceGenerator(game.GetUniverse());
+    SysProduction(game.GetUniverse());
+    SysDemandCreator(game.GetUniverse());
+    SysFactoryDemandCreator(game.GetUniverse());
     END_TIMED_BLOCK(Resource_gen);
     BEGIN_TIMED_BLOCK(Market_sim);
-    SysGoodSeller(universe);
-    SysPriceDetermine(universe);
-    SysDemandResolver(universe);
+    SysGoodSeller(game.GetUniverse());
+    SysPriceDetermine(game.GetUniverse());
+    SysDemandResolver(game.GetUniverse());
     END_TIMED_BLOCK(Market_sim);
     BEGIN_TIMED_BLOCK(Production_sim);
     // TODO(EhWhoAmI): If we are to sim things properly, SysFactory should go here
-    SysConsumptionConsume(universe);
-    SysProductionStarter(universe);
+    SysConsumptionConsume(game.GetUniverse());
+    SysProductionStarter(game.GetUniverse());
     END_TIMED_BLOCK(Production_sim);
     END_TIMED_BLOCK(SysEconomy);
 }

--- a/src/common/systems/economy/syseconomy.cpp
+++ b/src/common/systems/economy/syseconomy.cpp
@@ -36,28 +36,28 @@
 //
 
 using cqsp::common::systems::SysEconomy;
-void SysEconomy::DoSystem(Game& game) {
+void SysEconomy::DoSystem() {
     namespace cqspc = cqsp::common::components;
     BEGIN_TIMED_BLOCK(SysEconomy);
-    WalletReset(game.GetUniverse());
-    SysCommercialProcess(game.GetUniverse());
-    SysEmploymentHandler(game.GetUniverse());
+    WalletReset(GetUniverse());
+    SysCommercialProcess(GetUniverse());
+    SysEmploymentHandler(GetUniverse());
     // Produce resources
     BEGIN_TIMED_BLOCK(Resource_gen);
-    SysResourceGenerator(game.GetUniverse());
-    SysProduction(game.GetUniverse());
-    SysDemandCreator(game.GetUniverse());
-    SysFactoryDemandCreator(game.GetUniverse());
+    SysResourceGenerator(GetUniverse());
+    SysProduction(GetUniverse());
+    SysDemandCreator(GetUniverse());
+    SysFactoryDemandCreator(GetUniverse());
     END_TIMED_BLOCK(Resource_gen);
     BEGIN_TIMED_BLOCK(Market_sim);
-    SysGoodSeller(game.GetUniverse());
-    SysPriceDetermine(game.GetUniverse());
-    SysDemandResolver(game.GetUniverse());
+    SysGoodSeller(GetUniverse());
+    SysPriceDetermine(GetUniverse());
+    SysDemandResolver(GetUniverse());
     END_TIMED_BLOCK(Market_sim);
     BEGIN_TIMED_BLOCK(Production_sim);
     // TODO(EhWhoAmI): If we are to sim things properly, SysFactory should go here
-    SysConsumptionConsume(game.GetUniverse());
-    SysProductionStarter(game.GetUniverse());
+    SysConsumptionConsume(GetUniverse());
+    SysProductionStarter(GetUniverse());
     END_TIMED_BLOCK(Production_sim);
     END_TIMED_BLOCK(SysEconomy);
 }

--- a/src/common/systems/economy/syseconomy.h
+++ b/src/common/systems/economy/syseconomy.h
@@ -21,7 +21,8 @@
 namespace cqsp::common::systems {
 class SysEconomy : public ISimulationSystem {
  public:
-    void DoSystem(Game& game);
+    explicit SysEconomy(Game& game) : ISimulationSystem(game) {}
+    void DoSystem();
 
  private:
     void WalletReset(Universe& universe);

--- a/src/common/systems/economy/syseconomy.h
+++ b/src/common/systems/economy/syseconomy.h
@@ -21,7 +21,7 @@
 namespace cqsp::common::systems {
 class SysEconomy : public ISimulationSystem {
  public:
-    void DoSystem(Universe& universe);
+    void DoSystem(Game& game);
 
  private:
     void WalletReset(Universe& universe);

--- a/src/common/systems/economy/sysfactory.cpp
+++ b/src/common/systems/economy/sysfactory.cpp
@@ -24,7 +24,9 @@
 #include "common/components/name.h"
 #include "common/components/infrastructure.h"
 
-void cqsp::common::systems::SysFactory::DoSystem(Universe& universe) {
+void cqsp::common::systems::SysFactory::DoSystem(Game& game) {
+    Universe& universe = game.GetUniverse();
+
     SysInfrastrutureChecker(universe);
     SysFactoryProduction(universe);
     SysMineProduction(universe);

--- a/src/common/systems/economy/sysfactory.cpp
+++ b/src/common/systems/economy/sysfactory.cpp
@@ -24,8 +24,8 @@
 #include "common/components/name.h"
 #include "common/components/infrastructure.h"
 
-void cqsp::common::systems::SysFactory::DoSystem(Game& game) {
-    Universe& universe = game.GetUniverse();
+void cqsp::common::systems::SysFactory::DoSystem() {
+    Universe& universe = GetGame().GetUniverse();
 
     SysInfrastrutureChecker(universe);
     SysFactoryProduction(universe);

--- a/src/common/systems/economy/sysfactory.h
+++ b/src/common/systems/economy/sysfactory.h
@@ -26,7 +26,7 @@ namespace cqsp::common::systems {
 /// </summary>
 class SysFactory : public ISimulationSystem {
  public:
-    void DoSystem(Universe& universe);
+    void DoSystem(Game& game);
 
  private:
     void SysFactoryProduction(Universe& universe);

--- a/src/common/systems/economy/sysfactory.h
+++ b/src/common/systems/economy/sysfactory.h
@@ -26,7 +26,8 @@ namespace cqsp::common::systems {
 /// </summary>
 class SysFactory : public ISimulationSystem {
  public:
-    void DoSystem(Game& game);
+    explicit SysFactory(Game& game) : ISimulationSystem(game) {}
+    void DoSystem();
 
  private:
     void SysFactoryProduction(Universe& universe);

--- a/src/common/systems/isimulationsystem.h
+++ b/src/common/systems/isimulationsystem.h
@@ -26,7 +26,7 @@ namespace common {
 namespace systems {
 class ISimulationSystem {
  public:
-    ISimulationSystem(Game& game) : game(game) {}
+    explicit ISimulationSystem(Game& game) : game(game) {}
 
     virtual void DoSystem() = 0;
     virtual int Interval() { return 25; }

--- a/src/common/systems/isimulationsystem.h
+++ b/src/common/systems/isimulationsystem.h
@@ -26,8 +26,17 @@ namespace common {
 namespace systems {
 class ISimulationSystem {
  public:
-    virtual void DoSystem(Game& game) = 0;
+    ISimulationSystem(Game& game) : game(game) {}
+
+    virtual void DoSystem() = 0;
     virtual int Interval() { return 25; }
+
+ protected:
+    Game& GetGame() { return game; }
+    Universe& GetUniverse() { return game.GetUniverse(); }
+
+ private:
+    Game& game;
 };
 }  // namespace systems
 }  // namespace common

--- a/src/common/systems/movement/sysmovement.cpp
+++ b/src/common/systems/movement/sysmovement.cpp
@@ -22,10 +22,11 @@
 #include "common/components/coordinates.h"
 #include "common/components/units.h"
 
-void cqsp::common::systems::SysOrbit::DoSystem(Universe& universe) {
+void cqsp::common::systems::SysOrbit::DoSystem(Game& game) {
     namespace cqspc = cqsp::common::components;
     namespace cqsps = cqsp::common::components::ships;
     namespace cqspt = cqsp::common::components::types;
+    Universe& universe = game.GetUniverse();
 
     auto bodies = universe.view<cqspt::Orbit>();
     for (entt::entity body : bodies) {
@@ -37,10 +38,12 @@ void cqsp::common::systems::SysOrbit::DoSystem(Universe& universe) {
 
 int cqsp::common::systems::SysOrbit::Interval() { return 1; }
 
-void cqsp::common::systems::SysSurface::DoSystem(Universe& universe) {
+void cqsp::common::systems::SysSurface::DoSystem(Game& game) {
     namespace cqspc = cqsp::common::components;
     namespace cqsps = cqsp::common::components::ships;
     namespace cqspt = cqsp::common::components::types;
+
+    Universe& universe = game.GetUniverse();
 
     auto objects = universe.view<cqspt::SurfaceCoordinate>();
     for (entt::entity object : objects) {
@@ -60,10 +63,11 @@ int cqsp::common::systems::SysSurface::Interval() {
     return 1;
 }
 
-void cqsp::common::systems::SysPath::DoSystem(Universe& universe) {
+void cqsp::common::systems::SysPath::DoSystem(Game& game) {
     namespace cqspc = cqsp::common::components;
     namespace cqsps = cqsp::common::components::ships;
     namespace cqspt = cqsp::common::components::types;
+    Universe& universe = game.GetUniverse();
 
     auto bodies = universe.view<cqspt::MoveTarget, cqspt::Kinematics>(entt::exclude<cqspt::Orbit>);
     for (entt::entity body : bodies) {

--- a/src/common/systems/movement/sysmovement.cpp
+++ b/src/common/systems/movement/sysmovement.cpp
@@ -22,11 +22,11 @@
 #include "common/components/coordinates.h"
 #include "common/components/units.h"
 
-void cqsp::common::systems::SysOrbit::DoSystem(Game& game) {
+void cqsp::common::systems::SysOrbit::DoSystem() {
     namespace cqspc = cqsp::common::components;
     namespace cqsps = cqsp::common::components::ships;
     namespace cqspt = cqsp::common::components::types;
-    Universe& universe = game.GetUniverse();
+    Universe& universe = GetGame().GetUniverse();
 
     auto bodies = universe.view<cqspt::Orbit>();
     for (entt::entity body : bodies) {
@@ -38,12 +38,12 @@ void cqsp::common::systems::SysOrbit::DoSystem(Game& game) {
 
 int cqsp::common::systems::SysOrbit::Interval() { return 1; }
 
-void cqsp::common::systems::SysSurface::DoSystem(Game& game) {
+void cqsp::common::systems::SysSurface::DoSystem() {
     namespace cqspc = cqsp::common::components;
     namespace cqsps = cqsp::common::components::ships;
     namespace cqspt = cqsp::common::components::types;
 
-    Universe& universe = game.GetUniverse();
+    Universe& universe = GetGame().GetUniverse();
 
     auto objects = universe.view<cqspt::SurfaceCoordinate>();
     for (entt::entity object : objects) {
@@ -63,11 +63,11 @@ int cqsp::common::systems::SysSurface::Interval() {
     return 1;
 }
 
-void cqsp::common::systems::SysPath::DoSystem(Game& game) {
+void cqsp::common::systems::SysPath::DoSystem() {
     namespace cqspc = cqsp::common::components;
     namespace cqsps = cqsp::common::components::ships;
     namespace cqspt = cqsp::common::components::types;
-    Universe& universe = game.GetUniverse();
+    Universe& universe = GetUniverse();
 
     auto bodies = universe.view<cqspt::MoveTarget, cqspt::Kinematics>(entt::exclude<cqspt::Orbit>);
     for (entt::entity body : bodies) {

--- a/src/common/systems/movement/sysmovement.h
+++ b/src/common/systems/movement/sysmovement.h
@@ -23,19 +23,22 @@ namespace common {
 namespace systems {
 class SysOrbit : public ISimulationSystem {
  public:
-     void DoSystem(Game& game);
-     int Interval();
+    explicit SysOrbit(Game& game) : ISimulationSystem(game) {}
+    void DoSystem();
+    int Interval();
 };
 
 class SysPath : public ISimulationSystem {
  public:
-     void DoSystem(Game& game);
-     int Interval();
+    explicit SysPath(Game& game) : ISimulationSystem(game) {}
+    void DoSystem();
+    int Interval();
 };
 
 class SysSurface : public ISimulationSystem {
  public:
-    void DoSystem(Game& game);
+    explicit SysSurface(Game& game) : ISimulationSystem(game) {}
+    void DoSystem();
     int Interval();
 };
 }  // namespace systems

--- a/src/common/systems/movement/sysmovement.h
+++ b/src/common/systems/movement/sysmovement.h
@@ -23,19 +23,19 @@ namespace common {
 namespace systems {
 class SysOrbit : public ISimulationSystem {
  public:
-     void DoSystem(Universe& universe);
+     void DoSystem(Game& game);
      int Interval();
 };
 
 class SysPath : public ISimulationSystem {
  public:
-     void DoSystem(Universe& universe);
+     void DoSystem(Game& game);
      int Interval();
 };
 
 class SysSurface : public ISimulationSystem {
  public:
-    void DoSystem(Universe& universe);
+    void DoSystem(Game& game);
     int Interval();
 };
 }  // namespace systems

--- a/src/common/systems/scriptrunner.cpp
+++ b/src/common/systems/scriptrunner.cpp
@@ -44,3 +44,14 @@ cqsp::common::systems::SysEventScriptRunner::~SysEventScriptRunner() {
     }
     events.clear();
 }
+
+cqsp::common::systems::SysScript::~SysScript() {
+    // So it doesn't crash when we delete this
+    for (auto& evet : events) {
+        evet.abandon();
+    }
+    events.clear();
+}
+
+void cqsp::common::systems::SysScript::DoSystem(Game &game) {
+}

--- a/src/common/systems/scriptrunner.cpp
+++ b/src/common/systems/scriptrunner.cpp
@@ -21,28 +21,11 @@
 #include <vector>
 #include <string>
 
-cqsp::common::systems::SysEventScriptRunner::SysEventScriptRunner(
-    cqsp::common::Universe &_universe,
-    scripting::ScriptInterface &interface) : universe(_universe), m_script_interface(interface) {
-        sol::optional<std::vector<sol::table>> optional = m_script_interface["events"]["data"];
-        events = *optional;
-    // Add functions and stuff
-}
+#include "common/util/profiler.h"
 
-void cqsp::common::systems::SysEventScriptRunner::ScriptEngine() {
-    m_script_interface["date"] = universe.date.GetDate();
-    for (auto &a : events) {
-        sol::protected_function_result result = a["on_tick"](a);
-        m_script_interface.ParseResult(result);
-    }
-}
-
-cqsp::common::systems::SysEventScriptRunner::~SysEventScriptRunner() {
-    // So it doesn't crash when we delete this
-    for (auto& evet : events) {
-        evet.abandon();
-    }
-    events.clear();
+cqsp::common::systems::SysScript::SysScript(Game &game)  : ISimulationSystem(game) {
+    sol::optional<std::vector<sol::table>> optional = game.GetScriptInterface()["events"]["data"];
+    events = *optional;
 }
 
 cqsp::common::systems::SysScript::~SysScript() {
@@ -54,4 +37,11 @@ cqsp::common::systems::SysScript::~SysScript() {
 }
 
 void cqsp::common::systems::SysScript::DoSystem() {
+    BEGIN_TIMED_BLOCK(ScriptEngine);
+    GetGame().GetScriptInterface()["date"] = GetUniverse().date.GetDate();
+    for (auto &a : events) {
+        sol::protected_function_result result = a["on_tick"](a);
+        GetGame().GetScriptInterface().ParseResult(result);
+    }
+    END_TIMED_BLOCK(ScriptEngine);
 }

--- a/src/common/systems/scriptrunner.cpp
+++ b/src/common/systems/scriptrunner.cpp
@@ -53,5 +53,5 @@ cqsp::common::systems::SysScript::~SysScript() {
     events.clear();
 }
 
-void cqsp::common::systems::SysScript::DoSystem(Game &game) {
+void cqsp::common::systems::SysScript::DoSystem() {
 }

--- a/src/common/systems/scriptrunner.h
+++ b/src/common/systems/scriptrunner.h
@@ -27,24 +27,12 @@ namespace common {
 namespace systems {
 class SysScript : public cqsp::common::systems::ISimulationSystem {
  public:
-    explicit SysScript(Game& game) : ISimulationSystem(game) {}
+    explicit SysScript(Game& game);
     ~SysScript();
     void DoSystem();
     int Interval() { return 1; }
 
  private:
-    std::vector<sol::table> events;
-};
-
-class SysEventScriptRunner {
- public:
-    SysEventScriptRunner(cqsp::common::Universe& _universe,
-                         scripting::ScriptInterface& interface);
-    void ScriptEngine();
-    ~SysEventScriptRunner();
- private:
-    scripting::ScriptInterface &m_script_interface;
-    cqsp::common::Universe& universe;
     std::vector<sol::table> events;
 };
 }  // namespace systems

--- a/src/common/systems/scriptrunner.h
+++ b/src/common/systems/scriptrunner.h
@@ -27,8 +27,9 @@ namespace common {
 namespace systems {
 class SysScript : public cqsp::common::systems::ISimulationSystem {
  public:
+    explicit SysScript(Game& game) : ISimulationSystem(game) {}
     ~SysScript();
-    void DoSystem(Game& game);
+    void DoSystem();
     int Interval() { return 1; }
 
  private:

--- a/src/common/systems/scriptrunner.h
+++ b/src/common/systems/scriptrunner.h
@@ -20,10 +20,21 @@
 
 #include "common/scripting/scripting.h"
 #include "common/universe.h"
+#include "common/systems/isimulationsystem.h"
 
 namespace cqsp {
 namespace common {
 namespace systems {
+class SysScript : public cqsp::common::systems::ISimulationSystem {
+ public:
+    ~SysScript();
+    void DoSystem(Game& game);
+    int Interval() { return 1; }
+
+ private:
+    std::vector<sol::table> events;
+};
+
 class SysEventScriptRunner {
  public:
     SysEventScriptRunner(cqsp::common::Universe& _universe,

--- a/src/common/systems/sysinfrastructure.cpp
+++ b/src/common/systems/sysinfrastructure.cpp
@@ -19,8 +19,9 @@
 #include "common/components/area.h"
 #include "common/components/infrastructure.h"
 
-void cqsp::common::systems::InfrastructureSim::DoSystem(Universe& universe) {
+void cqsp::common::systems::InfrastructureSim::DoSystem(Game& game) {
     namespace cqspc = cqsp::common::components;
+    Universe& universe = game.GetUniverse();
     // Get all cities with industry and infrastruture
     auto view = universe.view<cqspc::Industry>();
     for (entt::entity entity : view) {

--- a/src/common/systems/sysinfrastructure.cpp
+++ b/src/common/systems/sysinfrastructure.cpp
@@ -19,9 +19,9 @@
 #include "common/components/area.h"
 #include "common/components/infrastructure.h"
 
-void cqsp::common::systems::InfrastructureSim::DoSystem(Game& game) {
+void cqsp::common::systems::InfrastructureSim::DoSystem() {
     namespace cqspc = cqsp::common::components;
-    Universe& universe = game.GetUniverse();
+    Universe& universe = GetUniverse();
     // Get all cities with industry and infrastruture
     auto view = universe.view<cqspc::Industry>();
     for (entt::entity entity : view) {

--- a/src/common/systems/sysinfrastructure.h
+++ b/src/common/systems/sysinfrastructure.h
@@ -23,7 +23,8 @@ namespace common {
 namespace systems {
 class InfrastructureSim : public ISimulationSystem {
  public:
-    void DoSystem(Game& game);
+    explicit InfrastructureSim(Game& game) : ISimulationSystem(game) {}
+    void DoSystem();
 };
 }  // namespace systems
 }  // namespace common

--- a/src/common/systems/sysinfrastructure.h
+++ b/src/common/systems/sysinfrastructure.h
@@ -23,7 +23,7 @@ namespace common {
 namespace systems {
 class InfrastructureSim : public ISimulationSystem {
  public:
-    void DoSystem(Universe& universe);
+    void DoSystem(Game& game);
 };
 }  // namespace systems
 }  // namespace common

--- a/src/common/systems/syspopulation.cpp
+++ b/src/common/systems/syspopulation.cpp
@@ -21,8 +21,10 @@
 #include "common/components/resource.h"
 #include "common/components/economy.h"
 
-void cqsp::common::systems::SysPopulationGrowth::DoSystem(Universe& universe) {
+void cqsp::common::systems::SysPopulationGrowth::DoSystem(Game& game) {
     namespace cqspc = cqsp::common::components;
+    Universe& universe = game.GetUniverse();
+
     auto view = universe.view<cqspc::PopulationSegment>();
     for (auto [entity, segment] : view.each()) {
         // If it's hungry, decay population
@@ -54,8 +56,10 @@ void cqsp::common::systems::SysPopulationGrowth::DoSystem(Universe& universe) {
     }
 }
 
-void cqsp::common::systems::SysPopulationConsumption::DoSystem(Universe& universe) {
+void cqsp::common::systems::SysPopulationConsumption::DoSystem(Game& game) {
     namespace cqspc = cqsp::common::components;
+    Universe& universe = game.GetUniverse();
+
     auto view = universe.view<cqspc::PopulationSegment>();
     for (auto [entity, segment] : view.each()) {
         // The population will feed, I guess

--- a/src/common/systems/syspopulation.cpp
+++ b/src/common/systems/syspopulation.cpp
@@ -21,9 +21,9 @@
 #include "common/components/resource.h"
 #include "common/components/economy.h"
 
-void cqsp::common::systems::SysPopulationGrowth::DoSystem(Game& game) {
+void cqsp::common::systems::SysPopulationGrowth::DoSystem() {
     namespace cqspc = cqsp::common::components;
-    Universe& universe = game.GetUniverse();
+    Universe& universe = GetUniverse();
 
     auto view = universe.view<cqspc::PopulationSegment>();
     for (auto [entity, segment] : view.each()) {
@@ -56,9 +56,9 @@ void cqsp::common::systems::SysPopulationGrowth::DoSystem(Game& game) {
     }
 }
 
-void cqsp::common::systems::SysPopulationConsumption::DoSystem(Game& game) {
+void cqsp::common::systems::SysPopulationConsumption::DoSystem() {
     namespace cqspc = cqsp::common::components;
-    Universe& universe = game.GetUniverse();
+    Universe& universe = GetUniverse();
 
     auto view = universe.view<cqspc::PopulationSegment>();
     for (auto [entity, segment] : view.each()) {

--- a/src/common/systems/syspopulation.h
+++ b/src/common/systems/syspopulation.h
@@ -21,12 +21,12 @@
 namespace cqsp::common::systems {
 class SysPopulationGrowth : public ISimulationSystem {
  public:
-    void DoSystem(Universe& universe);
+    void DoSystem(Game& game);
     int Interval() { return 625; }
 };
 
 class SysPopulationConsumption : public ISimulationSystem {
  public:
-    void DoSystem(Universe& universe);
+    void DoSystem(Game& game);
 };
 }  // namespace cqsp::common::systems

--- a/src/common/systems/syspopulation.h
+++ b/src/common/systems/syspopulation.h
@@ -21,12 +21,14 @@
 namespace cqsp::common::systems {
 class SysPopulationGrowth : public ISimulationSystem {
  public:
-    void DoSystem(Game& game);
+    explicit SysPopulationGrowth(Game& game) : ISimulationSystem(game) {}
+    void DoSystem();
     int Interval() { return 625; }
 };
 
 class SysPopulationConsumption : public ISimulationSystem {
  public:
-    void DoSystem(Game& game);
+    explicit SysPopulationConsumption(Game& game) : ISimulationSystem(game) {}
+    void DoSystem();
 };
 }  // namespace cqsp::common::systems

--- a/src/common/universe.h
+++ b/src/common/universe.h
@@ -39,6 +39,7 @@ class Universe : public entt::registry {
     void EnableTick() { to_tick = true; }
     void DisableTick() { to_tick = false; }
     bool ToTick() { return to_tick; }
+
     std::unique_ptr<cqsp::common::util::IRandom> random;
  private:
     bool to_tick = false;

--- a/src/engine/application.cpp
+++ b/src/engine/application.cpp
@@ -368,9 +368,7 @@ int cqsp::engine::Application::init() {
     std::unique_ptr<Scene> initial_scene = std::make_unique<EmptyScene>(*this);
     m_scene_manager.SetInitialScene(std::move(initial_scene));
 
-    m_script_interface = std::make_unique<cqsp::scripting::ScriptInterface>();
-    m_universe = std::make_unique<cqsp::common::Universe>();
-    m_script_interface->Init();
+    m_game = std::make_unique<cqsp::common::Game>();
     return 0;
 }
 
@@ -381,30 +379,27 @@ int cqsp::engine::Application::destroy() {
     SPDLOG_INFO("Done Destroying scene");
 
     // Clear assets
-    SPDLOG_INFO("Deleting universe");
-    m_universe.reset();
-    SPDLOG_INFO("Done deleting universe");
-
-    SPDLOG_INFO("Deleting script interface");
-    m_script_interface.reset();
-    SPDLOG_INFO("Done deleting script interface");
+    SPDLOG_INFO("Deleting game");
+    m_game.reset();
+    SPDLOG_INFO("Deleted game");
 
     SPDLOG_INFO("Deleting audio interface");
     m_audio_interface->Destruct();
-    SPDLOG_INFO("Done deleting audio interface");
+    SPDLOG_INFO("Deleted audio interface");
 
     SPDLOG_INFO("Clearing assets");
     manager.ClearAssets();
-    SPDLOG_INFO("Done clearing assets");
+    SPDLOG_INFO("Cleared assets");
 
     SPDLOG_INFO("Deleting audio interface");
     delete m_audio_interface;
-    SPDLOG_INFO("Done audio interface");
+    SPDLOG_INFO("Deleted audio interface");
 
     ImGui_ImplOpenGL3_Shutdown();
     ImGui_ImplGlfw_Shutdown();
     ImPlot::DestroyContext();
     ImGui::DestroyContext();
+    SPDLOG_INFO("Killed ImGui");
 
     glfwDestroyWindow(window(m_window));
     glfwTerminate();
@@ -414,6 +409,9 @@ int cqsp::engine::Application::destroy() {
     std::ofstream config_path(m_client_options.GetDefaultLocation(),
                               std::ios::trunc);
     m_client_options.WriteOptions(config_path);
+
+    SPDLOG_INFO("Saved config");
+    SPDLOG_INFO("Good bye");
     spdlog::shutdown();
     return 0;
 }

--- a/src/engine/application.h
+++ b/src/engine/application.h
@@ -29,10 +29,9 @@
 #include "engine/engine.h"
 #include "engine/scene.h"
 #include "engine/asset/assetmanager.h"
-#include "common/universe.h"
 #include "engine/gui.h"
 #include "engine/graphics/text.h"
-#include "common/scripting/scripting.h"
+#include "common/game.h"
 #include "engine/audio/iaudiointerface.h"
 #include "engine/window.h"
 
@@ -131,10 +130,14 @@ class Application {
 
     ImGui::MarkdownConfig markdownConfig;
 
-    cqsp::common::Universe& GetUniverse() { return *m_universe; }
+    cqsp::common::Universe& GetUniverse() { return m_game->GetUniverse(); }
+
+    cqsp::common::Game& GetGame() { return *m_game; }
+
     cqsp::scripting::ScriptInterface& GetScriptInterface() {
-        return *m_script_interface;
+        return m_game->GetScriptInterface();
     }
+
     cqsp::engine::audio::IAudioInterface& GetAudioInterface() {
         return *m_audio_interface;
     }
@@ -230,14 +233,12 @@ class Application {
 
     cqsp::asset::AssetManager manager;
 
-    std::unique_ptr<cqsp::common::Universe> m_universe;
+    std::unique_ptr<cqsp::common::Game> m_game;
 
     cqsp::asset::Font* m_font = nullptr;
     cqsp::asset::ShaderProgram* fontShader = nullptr;
 
     std::map<std::string, std::string> properties;
-
-    std::unique_ptr<cqsp::scripting::ScriptInterface> m_script_interface;
 
     cqsp::engine::audio::IAudioInterface *m_audio_interface;
 

--- a/test/common/simulation/movementtest.cpp
+++ b/test/common/simulation/movementtest.cpp
@@ -77,7 +77,7 @@ TEST_F(SystemsMovementTest, ShipMovementTest) {
     cqsp::common::Universe& universe = m_game.GetUniverse();
 
     // Do it a couple of times and see if it arrives
-    cqsp::common::systems::SysPath system;
+    cqsp::common::systems::SysPath system(m_game);
 
     // Ensure system is the same
     EXPECT_TRUE(universe.valid(ship));
@@ -87,7 +87,7 @@ TEST_F(SystemsMovementTest, ShipMovementTest) {
 
     universe.emplace_or_replace<cqspt::MoveTarget>(ship, target);
     for (int i = 0; i < 1000; i++) {
-        system.DoSystem(m_game);
+        system.DoSystem();
     }
     auto& position = universe.get<cqspt::Kinematics>(ship);
     glm::vec3 vec = cqspt::toVec3(universe.get<cqspt::Orbit>(target));

--- a/test/common/simulation/movementtest.cpp
+++ b/test/common/simulation/movementtest.cpp
@@ -26,6 +26,7 @@ namespace cqspt = cqsp::common::components::types;
 class SystemsMovementTest : public ::testing::Test {
  protected:
     static void SetUpTestSuite() {
+        cqsp::common::Universe& universe = m_game.GetUniverse();
         star_system = universe.create();
 
         universe.emplace<cqsp::common::components::bodies::StarSystem>(star_system);
@@ -47,16 +48,18 @@ class SystemsMovementTest : public ::testing::Test {
     static entt::entity planet;
     static entt::entity ship;
     static entt::entity target;
-    static cqsp::common::Universe universe;
+    static cqsp::common::Game m_game;
 };
 
-cqsp::common::Universe SystemsMovementTest::universe = cqsp::common::Universe();
+cqsp::common::Game SystemsMovementTest::m_game = cqsp::common::Game();
 entt::entity SystemsMovementTest::star_system = entt::null;
 entt::entity SystemsMovementTest::planet = entt::null;
 entt::entity SystemsMovementTest::ship = entt::null;
 entt::entity SystemsMovementTest::target = entt::null;
 
 TEST_F(SystemsMovementTest, ShipCreationTest) {
+    cqsp::common::Universe& universe = m_game.GetUniverse();
+
     // Test out if the ship is created
     ship = cqsp::common::systems::actions::CreateShip(universe, entt::null,
                                                        planet, star_system);
@@ -71,6 +74,8 @@ TEST_F(SystemsMovementTest, ShipCreationTest) {
 }
 
 TEST_F(SystemsMovementTest, ShipMovementTest) {
+    cqsp::common::Universe& universe = m_game.GetUniverse();
+
     // Do it a couple of times and see if it arrives
     cqsp::common::systems::SysPath system;
 
@@ -82,7 +87,7 @@ TEST_F(SystemsMovementTest, ShipMovementTest) {
 
     universe.emplace_or_replace<cqspt::MoveTarget>(ship, target);
     for (int i = 0; i < 1000; i++) {
-        system.DoSystem(universe);
+        system.DoSystem(m_game);
     }
     auto& position = universe.get<cqspt::Kinematics>(ship);
     glm::vec3 vec = cqspt::toVec3(universe.get<cqspt::Orbit>(target));


### PR DESCRIPTION
This unifies the universe and script engine, that was previously defined in the application, to a new class, the `Game` class. This allows us to add more attributes and variables to the game without needing to add more arguments to classes and functions.

This also makes all systems retain the game object class, so that we don't need to pass the game argument over and over again.

This also makes the script runner become a system, so we don't have a separate dealing with the scripts.